### PR TITLE
feat: add Typeahead component

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jest": "^16.0.1",
     "node-sass": "^3.10.1",
     "react": "^15.3.2",
+    "react-autowhatever": "^7.0.0",
     "react-a11y": "^0.3.3",
     "react-addons-test-utils": "^15.3.2",
     "react-bootstrap": "0",

--- a/src/Typeahead/Typeahead.component.js
+++ b/src/Typeahead/Typeahead.component.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import {PropTypes} from 'react';
+import Autowhatever from 'react-autowhatever';
+import scssTheme from './Typeahead.scss';
+
+/**
+ * @param {object} props react props
+ * @example
+	 <Typeahead
+		 id={comonentId}
+		 items={items}
+		 renderItem={renderItem}
+		 inputProps={inputProps}
+		 itemProps={itemProps}
+	 />
+ */
+function Typeahead(props) {
+	const eprops = Object.assign({}, props);
+	eprops.theme = {
+		container: props.theme && props.theme.container || scssTheme['awe-container'],
+		containerOpen: props.theme && props.theme.containerOpen || scssTheme['awe-containerOpen'],
+		highlight: props.theme && props.theme.highlight || scssTheme['awe-highlight'],
+		input: props.theme && props.theme.input || scssTheme['awe-input'],
+		item: props.theme && props.theme.item || scssTheme['awe-item'],
+		itemFocused: props.theme && props.theme.itemFocused || scssTheme['awe-itemFocused'],
+		itemsContainer: props.theme && props.theme.itemsContainer || scssTheme['awe-itemsContainer'],
+		itemsList: props.theme && props.theme.itemsList || scssTheme['awe-itemsList'],
+		sectionContainer: props.theme && props.theme.sectionContainer || scssTheme['awe-sectionContainer'],
+		sectionTitle: props.theme && props.theme.sectionTitle || scssTheme['awe-sectionTitle'],
+	};
+
+	console.log('//////////////////////', eprops);
+	return (<Autowhatever {...eprops}/>);
+}
+
+Typeahead.propTypes = {
+	id: PropTypes.string,                  // Used in aria-* attributes. If multiple Autowhatever's are rendered on a page, they must have unique ids.
+	multiSection: PropTypes.bool,          // Indicates whether a multi section layout should be rendered.
+	renderInputComponent: PropTypes.func,  // Renders the input component.
+	items: PropTypes.array.isRequired,     // Array of items or sections to render.
+	renderItemsContainer: PropTypes.func,  // Renders the items container.
+	renderItem: PropTypes.func,            // This function renders a single item.
+	renderItemData: PropTypes.object,      // Arbitrary data that will be passed to renderItem()
+	shouldRenderSection: PropTypes.func,   // This function gets a section and returns whether it should be rendered, or not.
+	renderSectionTitle: PropTypes.func,    // This function gets a section and renders its title.
+	getSectionItems: PropTypes.func,       // This function gets a section and returns its items, which will be passed into `renderItem` for rendering.
+	inputComponent: PropTypes.func,        // When specified, it is used to render the input element
+	inputProps: PropTypes.object,          // Arbitrary input props
+	itemProps: PropTypes.oneOfType([       // Arbitrary item props
+		PropTypes.object,
+		PropTypes.func,
+	]),
+	focusedSectionIndex: PropTypes.number, // Section index of the focused item
+	focusedItemIndex: PropTypes.number,    // Focused item index (within a section)
+	theme: PropTypes.oneOfType([           // Styles. See: https://github.com/markdalgleish/react-themeable
+		PropTypes.object,
+		PropTypes.array,
+	]),
+};
+
+export default Typeahead;

--- a/src/Typeahead/Typeahead.css
+++ b/src/Typeahead/Typeahead.css
@@ -1,0 +1,3 @@
+
+
+/*# sourceMappingURL=Typeahead.css.map */

--- a/src/Typeahead/Typeahead.css.map
+++ b/src/Typeahead/Typeahead.css.map
@@ -1,0 +1,7 @@
+{
+"version": 3,
+"mappings": "",
+"sources": [],
+"names": [],
+"file": "Typeahead.css"
+}

--- a/src/Typeahead/Typeahead.scss
+++ b/src/Typeahead/Typeahead.scss
@@ -1,0 +1,74 @@
+.awe-container {
+  position: relative;
+}
+
+.awe-input {
+  width: 240px;
+  height: 30px;
+  box-sizing: content-box;
+  font-style: italic;
+  color: #7531ff;
+  background: none;
+  border: none;
+  border-bottom: 1px solid #FFF;
+  border-radius: 0;
+}
+
+.awe-containerOpen {
+  .awe-input {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+.awe-itemsContainer {
+  display: none;
+}
+
+.awe-containerOpen {
+  .awe-itemsContainer {
+    display: block;
+    position: relative;
+    top: -1px;
+    width: 270px;
+    border: 1px solid #aaa;
+    background-color: #fff;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    z-index: 2;
+    max-height: 160px;
+    overflow-y: auto;
+  }
+}
+
+.awe-itemsList {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.awe-item {
+  cursor: pointer;
+}
+
+.awe-itemFocused {
+  background-color: #ddd;
+}
+
+.awe-sectionTitle {
+  padding: 10px 0 0 10px;
+  font-size: 12px;
+  color: #777;
+  border-top: 1px dashed #ccc;
+}
+
+.awe-sectionContainer:first-child {
+  .awe-sectionTitle {
+    border-top: 0;
+  }
+}
+
+.awe-highlight {
+  color: #ee0000;
+  font-weight: 400;
+}

--- a/src/Typeahead/Typeahead.test.js
+++ b/src/Typeahead/Typeahead.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { shallow } from 'enzyme';
+
+import Typeahead from './Typeahead.component';
+
+describe('Typeahead', () => {
+	it('should render its name', () => {
+		const wrapper = shallow(<Typeahead name="Hello world" />);
+		expect(wrapper.containsMatchingElement(<div>Hello world</div>)).toBe(true);
+	});
+});

--- a/src/Typeahead/index.js
+++ b/src/Typeahead/index.js
@@ -1,0 +1,3 @@
+import Typeahead from './Typeahead.component';
+
+export default Typeahead;

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ import Icon from './Icon';
 import Layout from './Layout';
 import List from './List';
 import SidePanel from './SidePanel';
+import Typeahead from './Typeahead';
 
 if (!Object.keys(Icon.registry).length) {
 	Object.keys(icons).forEach((icon) => {
@@ -91,6 +92,7 @@ export {
 	Layout,
 	List,
 	SidePanel,
+	Typeahead,
 
 	Alert,
 	Badge,

--- a/stories/Mailbox.js
+++ b/stories/Mailbox.js
@@ -1,0 +1,30 @@
+import { storiesOf, action } from '@kadira/storybook';
+import React, { Component, PropTypes } from 'react';
+
+class Item extends Component {
+	static propTypes = {
+		item: PropTypes.any.isRequired,
+		onClick: PropTypes.func
+	};
+
+	render() {
+		const { item, ...restProps } = this.props;
+
+		return (
+			<li role="option" {...restProps}>
+				{item}
+			</li>
+		);
+	}
+}
+
+storiesOf('Test events in a loop', module)
+	.add('list items', () => {
+		const props = {
+			onClick: action('clicked')
+		};
+
+		return (<ul>
+			{[1,2,3].map((item, index) => (<Item item={item} key={index} {...props} />))}
+		</ul>);
+	});

--- a/stories/Typeahead.js
+++ b/stories/Typeahead.js
@@ -1,0 +1,103 @@
+import Autowhatever from 'react-autowhatever';
+import React from 'react';
+import { storiesOf, action } from '@kadira/storybook';
+import { FormControl } from 'react-bootstrap';
+import scssTheme from './typeahead.scss';
+import { Typeahead } from '../src';
+
+
+storiesOf('Typeahead', module)
+	.addWithInfo('basic', () => {
+		const exampleId = '5';
+		const items = [{text: 'Apple'}, {text: 'Banana'}, {text: 'Cherry'}, {text: 'Grapefruit'}, {text: 'Lemon'}];
+		function renderItem(item) {
+			return (<span>{item.text}</span>)
+		}
+		const value = '';
+		const focusedSectionIndex = null;
+		const focusedItemIndex = 0;
+		const onClick = (event, { itemIndex }) => {console.log('onClick ' + itemIndex + ' ', event);}
+		const inputProps = { value };
+		const itemProps = { onClick };
+
+		return (
+			<div>
+				<Autowhatever
+					id={exampleId}
+					items={items}
+					renderItem={renderItem}
+					inputProps={inputProps}
+					itemProps={itemProps}
+					focusedSectionIndex={focusedSectionIndex}
+					focusedItemIndex={focusedItemIndex}
+					theme={scssTheme}
+				/>
+			</div>
+		);
+	})
+
+	.addWithInfo('Search box', () => {
+		const exampleId = 'component-id';
+		const fruits = [{ text: 'Apple' }, { text: 'Banana' }, { text: 'Cherry' }, { text: 'Grapefruit' }, { text: 'Lemon' }, { text: 'Mango' }, { text: 'Pineapple' }, { text: 'Melon' }, { text: 'Orange' }];
+
+		let { value, items, focusedSectionIndex, focusedItemIndex} = {
+			value: '',
+			items: fruits,
+			focusedSectionIndex: null,
+			focusedItemIndex: 1
+		};
+
+		const inputProps = {
+			'value': '',
+			'placeholder': 'Search anything',
+		};
+
+		// Input actions
+		const inputActionsList = ['onChange', 'onFocus', 'onBlur'];
+		inputActionsList.forEach((funcName) => inputProps[funcName] = action(funcName + ' event on input is triggered'));
+
+		// Item actions
+		const itemActionsList = ['onMouseEnter', 'onMouseLeave', 'onMouseDown', 'onClick'];
+		const itemProps = {};
+		itemActionsList.forEach((funcName) => itemProps[funcName] = action(funcName + ' event on item in the list is triggered'));
+
+		const renderItemsContainer = ({ ...rest }) => {
+			return (
+				<div {...rest}></div>
+			);
+		};
+
+		function renderItem(fruit, index) {
+			return (
+				<span className="className" key={index}>{fruit.text}</span>
+			);
+		}
+
+		const renderInputComponent = inputProps => {
+			return (
+				<FormControl {...inputProps} />
+			);
+		};
+
+		const theme = {
+			itemFocused: scssTheme['custom-focused-item']
+		};
+
+		return (
+			<div>
+				<h2>Below is an example of a search box</h2>
+				<Typeahead
+					id={exampleId}
+					items={items}
+					renderItemsContainer={renderItemsContainer}
+					renderInputComponent={renderInputComponent}
+					renderItem={renderItem}
+					inputProps={inputProps}
+					focusedSectionIndex={focusedSectionIndex}
+					focusedItemIndex={focusedItemIndex}
+					itemProps={itemProps}
+				    theme={theme}
+				/>
+			</div>
+		);
+	});

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,3 +6,6 @@ import './Icon';
 import './Layout';
 import './List';
 import './SidePanel';
+// import './Autowhatever/Autowhatever';
+import './Typeahead';
+import './Mailbox';

--- a/stories/typeahead.scss
+++ b/stories/typeahead.scss
@@ -1,0 +1,4 @@
+.custom-focused-item {
+  color: blue;
+  background-color: #01ff70;
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
1. The story is missing some needs: the events are only attached to the 1st item in the list
2. You could face an error, while refreshing the page when the Typeahead is selected (just refresh the page on another component, then select the Typeahead)
3. As you can see there is a scss file int stories folder, I put it intentionally to show the case that it's possible to send a theme to the Typeahead component. 

**What is the new behavior?**
A basic customized story for the Typeahead  


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

